### PR TITLE
Add missing dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,10 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 
 #gem 'rails_12factor'
 
+# It's always good to have a place to store your data!
+gem 'sqlite3'
+# A JavaScript runtime for Rails to use
+gem 'therubyracer'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.2)
+    libv8 (3.16.14.19)
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -103,6 +104,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     rdoc (4.3.0)
+    ref (2.0.0)
     sass (3.4.13)
     sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -120,6 +122,10 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    sqlite3 (1.3.13)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -148,6 +154,8 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spring
+  sqlite3
+  therubyracer
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)


### PR DESCRIPTION
This PR fixes a couple of problems with the Gemfiles in this repo.

Firstly, it adds a sqlite driver for ActiveRecord to use. Secondly it adds a JavaScript engine because for some god-awful reason that's a requirement of Rails.